### PR TITLE
add custom json encoder/decoder with implemented datetime classes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@ import os
 import logging
 import json
 import aiosqlite
+import datetime
 
 from opsdroid.const import DEFAULT_ROOT_PATH
 from opsdroid.database import Database
@@ -36,7 +37,7 @@ class DatabaseSqlite(Database):
     async def put(self, key, data):
         """Insert or replace an object into the database for a given key."""
         logging.debug("Putting " + key + " into sqlite")
-        json_data = json.dumps(data)
+        json_data = json.dumps(data, cls=JSONEncoder)
         async with aiosqlite.connect(self.db_file, **self.conn_args) as db:
             cur = await db.cursor()
             await cur.execute(
@@ -55,5 +56,57 @@ class DatabaseSqlite(Database):
                 "SELECT data FROM {} WHERE key=?".format(self.table), (key,))
             row = await cur.fetchone()
             if row:
-                data = json.loads(row[0])
+                data = json.loads(row[0], object_hook=JSONDecoder())
         return data
+
+
+class JSONEncoder(json.JSONEncoder):
+
+    serializers = {}
+
+    def default(self, obj):
+        marshaller = self.serializers.get(
+            type(obj), super(JSONEncoder, self).default)
+        return marshaller(obj)
+
+
+class JSONDecoder(object):
+
+    decoders = {}
+
+    def __call__(self, dct):
+        if dct.get('__class__') in self.decoders:
+            return self.decoders[dct['__class__']](dct)
+        return dct
+
+
+def register_json_type(type_cls, fields, decode_fn):
+    type_name = type_cls.__name__
+    JSONEncoder.serializers[type_cls] = lambda obj: dict(
+        __class__=type_name,
+        **{field: getattr(obj, field) for field in fields}
+    )
+    JSONDecoder.decoders[type_name] = decode_fn
+
+
+register_json_type(
+    datetime.datetime,
+    ['year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond'],
+    lambda dct: datetime.datetime(
+        dct['year'], dct['month'], dct['day'],
+        dct['hour'], dct['minute'], dct['second'], dct['microsecond']
+    )
+)
+
+register_json_type(
+    datetime.date,
+    ['year', 'month', 'day'],
+    lambda dct: datetime.date(dct['year'], dct['month'], dct['day'])
+)
+
+register_json_type(
+    datetime.time,
+    ['hour', 'minute', 'second', 'microsecond'],
+    lambda dct: datetime.time(
+        dct['hour'], dct['minute'], dct['second'], dct['microsecond'])
+)


### PR DESCRIPTION
With this commit, sqlite database connector wins capabilities to work with python datetimes.
As a plus, it creates an interface to register other types of custom python objects.

I know I have write access, but I would like some code review :)